### PR TITLE
Added Content field to Create route

### DIFF
--- a/Amoraitis.TodoList/Controllers/TodosController.cs
+++ b/Amoraitis.TodoList/Controllers/TodosController.cs
@@ -72,7 +72,7 @@ namespace Amoraitis.TodoList.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("Title,DuetoDateTime")]TodoItem todo)
+        public async Task<IActionResult> Create([Bind("Title,Content,DuetoDateTime")]TodoItem todo)
         {
             if (!ModelState.IsValid)
             {

--- a/Amoraitis.TodoList/Views/Todos/Create.cshtml
+++ b/Amoraitis.TodoList/Views/Todos/Create.cshtml
@@ -18,6 +18,11 @@
                 <span asp-validation-for="Title" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Content" class="control-label"></label>
+                <input asp-for="Content" class="form-control" />
+                <span asp-validation-for="Content" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <label asp-for="DuetoDateTime" class="control-label"></label>
                 <input asp-for="DuetoDateTime" class="form-control" />
                 <span asp-validation-for="DuetoDateTime" class="text-danger"></span>


### PR DESCRIPTION
I couldn't avoid notice that the app lets you specify a content for your todos at the time of editing but not while creating, I assumed this was just a misfortunate mistake and added the field in the `Create` route. Now you can specify the content at the time of creating the todo item 👌