### PR TITLE
Enhancement/test coverage for controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ __pycache__/
 
 // lib files
 Amoraitis.TodoList/wwwroot/lib/
+.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ dotnet: 2.1.402
 script:
  - dotnet restore
  - dotnet build Amoraitis.TodoList/Amoraitis.TodoList.csproj
+ - dotnet test Amoraitis.Todo.UnitTests/

--- a/Amoraitis.Todo.UnitTests/Amoraitis.Todo.UnitTests.csproj
+++ b/Amoraitis.Todo.UnitTests/Amoraitis.Todo.UnitTests.csproj
@@ -13,6 +13,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.All"  Version="2.1.5" />
+    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Amoraitis.Todo.UnitTests/Controllers/AccountControllerTest.cs
+++ b/Amoraitis.Todo.UnitTests/Controllers/AccountControllerTest.cs
@@ -1,0 +1,649 @@
+using System;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using Amoraitis.Todo.UnitTests.Resources;
+using Amoraitis.TodoList.Controllers;
+using Amoraitis.TodoList.Models;
+using Amoraitis.TodoList.Models.AccountViewModels;
+using Amoraitis.TodoList.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Amoraitis.Todo.UnitTests.Controllers
+{
+    public class AccountControllerTest
+    {
+        private Mock<FakeUserManager> _userManagerMock;
+        private Mock<FakeSignInManager> _signInManagerMock;
+        private Mock<IEmailSender> _emailSenderMock;
+        private Mock<ILogger<AccountController>> _loggerMock;
+
+        private AccountController _accountController;
+
+        public AccountControllerTest()
+        {
+            this._userManagerMock =  new Mock<FakeUserManager>();
+            this._signInManagerMock = new Mock<FakeSignInManager>();
+            this._emailSenderMock =  new Mock<IEmailSender>();
+            this._loggerMock = new Mock<ILogger<AccountController>>();
+
+            _signInManagerMock
+                .Setup(manager => manager.GetTwoFactorAuthenticationUserAsync())
+                .ReturnsAsync(new ApplicationUser());
+
+            this._accountController = new AccountController(_userManagerMock.Object,
+                    _signInManagerMock.Object,
+                    _emailSenderMock.Object,
+                    _loggerMock.Object);
+
+            this._accountController.ControllerContext = new ControllerContext();
+            this._accountController.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            var authManager = new Mock<IAuthenticationService>();
+
+            authManager.Setup(service => service.SignOutAsync(It.IsAny<HttpContext>(),
+                It.IsAny<string>(),
+                It.IsAny<AuthenticationProperties>()))
+                .Returns(Task.FromResult(true));
+
+            var servicesMock = new Mock<IServiceProvider>();
+
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IAuthenticationService)))
+                .Returns(authManager.Object);
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IUrlHelperFactory)))
+                .Returns(new UrlHelperFactory());
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(ITempDataDictionaryFactory)))
+                .Returns(new TempDataDictionaryFactory(new SessionStateTempDataProvider()));
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IPrincipal)))
+                .Returns(new ClaimsPrincipal());
+
+            this._accountController.ControllerContext.HttpContext.RequestServices = servicesMock.Object;
+        }
+
+        [Fact]
+        public async Task GetLogin_ReturnsViewResult()
+        {
+            var result = await _accountController.Login();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Null(viewResult.ViewData["ReturnUrl"]);
+        }
+
+        [Fact]
+        public async Task PostLogin_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            var user = new LoginViewModel { Email = "max@example", Password = "abcDEF123_", RememberMe = true };
+
+            _signInManagerMock
+                .Setup(manager => manager.PasswordSignInAsync(user.Email, user.Password, user.RememberMe, false))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+            var result = await _accountController.Login(user);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLogin_ReturnsViewResult_WhenIsModelIsNotValid()
+        {
+            _accountController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _accountController.Login(new LoginViewModel());
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<LoginViewModel>(viewResult.ViewData.Model);
+        }
+
+        [Fact]
+        public async Task PostLogin_ReturnsRedirectToActionResult_WhenIsIsLockedOut()
+        {
+            var user = new LoginViewModel { Email = "max@example", Password = "abcDEF123_", RememberMe = true };
+
+            _signInManagerMock
+                .Setup(manager => manager.PasswordSignInAsync(user.Email, user.Password, user.RememberMe, false))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
+
+            var result = await _accountController.Login(user);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Lockout", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLogin_ReturnsRedirectToActionResult_WhenRequiredTwoAuthenticationFactors()
+        {
+            var user = new LoginViewModel { Email = "max@example", Password = "abcDEF123_", RememberMe = true };
+
+            _signInManagerMock
+                .Setup(manager => manager.PasswordSignInAsync(user.Email, user.Password, user.RememberMe, false))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.TwoFactorRequired);
+
+            var result = await _accountController.Login(user);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("LoginWith2fa", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLogin_ReturnsViewResult_WhenLoginAttemptIsInvalid()
+        {
+            var user = new LoginViewModel { Email = "max@example", Password = "abcDEF123_", RememberMe = true };
+
+            _signInManagerMock
+                .Setup(manager => manager.PasswordSignInAsync(user.Email, user.Password, user.RememberMe, false))
+                .ReturnsAsync(new Microsoft.AspNetCore.Identity.SignInResult());
+
+            var result = await _accountController.Login(user);
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<LoginViewModel>(viewResult.ViewData.Model);
+            Assert.Equal("Invalid login attempt.", _accountController.ModelState["INVALID_LOGIN_ATTEMPT"].Errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public async Task LoginWith2fa_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = await _accountController.LoginWith2fa(true);
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<LoginWith2faViewModel>(viewResult.ViewData.Model);
+            Assert.Null(viewResult.ViewData["ReturnUrl"]);
+        }
+
+        [Fact]
+        public async Task LoginWith2fa_ThrowsApplicationException_WhenUserIsNull()
+        {
+            SetGetTwoFactorAuthenticationUserAsyncToNull();
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _accountController.LoginWith2fa(true));
+
+            Assert.Equal("Unable to load two-factor authentication user.", exception.Message);
+        }
+
+        private void SetGetTwoFactorAuthenticationUserAsyncToNull()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.GetTwoFactorAuthenticationUserAsync())
+                .ReturnsAsync(() => null);
+        }
+
+        [Fact]
+        public async Task PostLoginWith2fa_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.TwoFactorAuthenticatorSignInAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+            var result = await _accountController.LoginWith2fa(new LoginWith2faViewModel { TwoFactorCode = "123 456" }, true, null);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLoginWith2fa_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _accountController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _accountController.LoginWith2fa(new LoginWith2faViewModel { TwoFactorCode = "123 456" }, true, null);
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task PostLoginWith2fa_ThrowsApplicationException_WhenUserIsNull()
+        {
+            SetGetTwoFactorAuthenticationUserAsyncToNull();
+
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1234");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _accountController.LoginWith2fa(new LoginWith2faViewModel { TwoFactorCode = "123 456" }, true, null));
+
+            Assert.Equal("Unable to load user with ID '1234'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostLoginWith2fa_ReturnsRedirectToActionResult_WhenIsLockedOut()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.TwoFactorAuthenticatorSignInAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
+
+            var result = await _accountController.LoginWith2fa(new LoginWith2faViewModel { TwoFactorCode = "123 456" }, true, null);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Lockout", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLoginWith2fa_ReturnsViewResult_WithErrors_WhenIsFailed()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.TwoFactorAuthenticatorSignInAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
+
+            var result = await _accountController.LoginWith2fa(new LoginWith2faViewModel { TwoFactorCode = "123 456" }, true, null);
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Null(viewResult.ViewName);
+            Assert.Equal("Invalid authenticator code.", _accountController.ModelState["INVALID_AUTHENTICATOR_CODE"].Errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public async Task LoginWithRecoveryCode_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = await _accountController.LoginWithRecoveryCode();
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Null(viewResult.ViewName);
+            Assert.Null(viewResult.ViewData["ReturnUrl"]);
+        }
+
+        [Fact]
+        public async Task LoginWithRecoveryCode_ThrowsApplicationException_WhenUserIsNull()
+        {
+            SetGetTwoFactorAuthenticationUserAsyncToNull();
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _accountController.LoginWithRecoveryCode());
+
+            Assert.Equal("Unable to load two-factor authentication user.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostLoginWithRecoveryCode_ReturnsRedictResult_WhenSucceeded()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.TwoFactorRecoveryCodeSignInAsync(It.IsAny<string>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+            var result = await _accountController.LoginWithRecoveryCode(
+                new LoginWithRecoveryCodeViewModel { RecoveryCode = "123 456" });
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLoginWithRecoveryCode_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _accountController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _accountController.LoginWithRecoveryCode(
+                new LoginWithRecoveryCodeViewModel { RecoveryCode = "123 456" });
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Null(viewResult.ViewName);
+            Assert.IsAssignableFrom<LoginWithRecoveryCodeViewModel>(viewResult.ViewData.Model);
+        }
+
+        [Fact]
+        public async Task PostLoginWithRecoveryCode_ThrowsApplicationException_WhenUserIsNull()
+        {
+            SetGetTwoFactorAuthenticationUserAsyncToNull();
+
+            var exception =  await Assert.ThrowsAsync<ApplicationException>(async() =>
+                await _accountController.LoginWithRecoveryCode(
+                    new LoginWithRecoveryCodeViewModel { RecoveryCode = "123 456" }));
+
+            Assert.Equal("Unable to load two-factor authentication user.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostLoginWithRecoveryCode_ReturnsRedirectResult_WhenIsLockedOut()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.TwoFactorRecoveryCodeSignInAsync(It.IsAny<string>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
+
+            var result = await _accountController.LoginWithRecoveryCode(
+                new LoginWithRecoveryCodeViewModel { RecoveryCode = "123 456" });
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Lockout", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostLoginWithRecoveryCode_ReturnsViewResult_WhenRecoveryCodeIsInvalid()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.TwoFactorRecoveryCodeSignInAsync(It.IsAny<string>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
+
+            var result = await _accountController.LoginWithRecoveryCode(
+                new LoginWithRecoveryCodeViewModel { RecoveryCode = "123 456" });
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Null(viewResult.ViewName);
+            Assert.Equal("Invalid recovery code entered.", _accountController.ModelState["INVALID_RECOVERY_CODE"].Errors[0].ErrorMessage);
+        }
+
+        [Fact]
+        public void Lockout_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.Lockout();
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public void Register_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.Register();
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Logout_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            var result = await _accountController.Logout();
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task ExternalLoginCallback_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(new ExternalLoginInfo(new ClaimsPrincipal(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            _signInManagerMock
+                .Setup(manager => manager.ExternalLoginSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Success);
+
+            var result = await _accountController.ExternalLoginCallback();
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task ExternalLoginCallback_ReturnsRedirectToActionResult_WithErrorMessage_WhenRemoteError()
+        {
+            var result = await _accountController.ExternalLoginCallback(null, "Test error");
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Login", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task ExternalLoginCallback_ReturnsRedirectToActionResult_WhenCanNotGetExternalLoginInfo()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(() => null);
+
+            var result = await _accountController.ExternalLoginCallback();
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Login", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task ExternalLoginCallback_ReturnsRedirectToActionResult_WhenIsLockedOut()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(new ExternalLoginInfo(new ClaimsPrincipal(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            _signInManagerMock
+                .Setup(manager => manager.ExternalLoginSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
+
+            var result = await _accountController.ExternalLoginCallback();
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Lockout", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task ExternalLoginCallback_ReturnsViewResult_WhenFailed()
+        {
+            var identity = new ClaimsIdentity();
+            var claimsPrincipal = new ClaimsPrincipal();
+
+            identity.AddClaim(new Claim(ClaimTypes.Email, "max@example.com"));
+            claimsPrincipal.AddIdentity(identity);
+
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(new ExternalLoginInfo(claimsPrincipal, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            _signInManagerMock
+                .Setup(manager => manager.ExternalLoginSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
+
+            var result = await _accountController.ExternalLoginCallback();
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<ExternalLoginViewModel>(viewResult.ViewData.Model);
+
+            Assert.Equal("ExternalLogin", viewResult.ViewName);
+            Assert.Equal("max@example.com", model.Email);
+        }
+
+        [Fact]
+        public async Task ExternalLoginConfirmation_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(new ExternalLoginInfo(new ClaimsPrincipal(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            _userManagerMock
+                .Setup(manager => manager.CreateAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+            _userManagerMock
+                .Setup(manager => manager.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+            var result = await _accountController.ExternalLoginConfirmation(new ExternalLoginViewModel{ Email = "max@example.com" });
+
+            Assert.IsType<RedirectToActionResult>(result);
+        }
+
+        [Fact]
+        public async Task ExternalLoginConfirmation_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _accountController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _accountController.ExternalLoginConfirmation(new ExternalLoginViewModel{ Email = "max@example.com" });
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ExternalLoginViewModel>(viewResult.ViewData.Model);
+            Assert.Equal("ExternalLogin", viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task ExternalLoginConfirmation_ThrowsApplicationException_WhenCanNotGetExternalLoginInfo()
+        {
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(null))
+                .ReturnsAsync(() => null);
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _accountController.ExternalLoginConfirmation(new ExternalLoginViewModel{ Email = "max@example.com" }));
+
+            Assert.Equal("Error loading external login information during confirmation.", exception.Message);
+        }
+
+        [Fact]
+        public async Task ConfirmEmail_ReturnsViewResult_WhenSucceeded()
+        {
+            _userManagerMock
+                .Setup(manager => manager.FindByIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ApplicationUser());
+
+            _userManagerMock
+                .Setup(manager => manager.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.IdentityResult.Success);
+
+            var result = await _accountController.ConfirmEmail("1234", "test_code");
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("ConfirmEmail", viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task ConfirmEmail_ReturnsRedirectToActionResult_WhenUserIdOrCodeIsNull()
+        {
+            var result = await _accountController.ConfirmEmail(null, null);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task ConfirmEmail_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.FindByIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => null);
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _accountController.ConfirmEmail("1234", "test_code"));
+
+            Assert.Equal("Unable to load user with ID '1234'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task ConfirmEmail_ReturnsViewResult_WhenFailed()
+        {
+            _userManagerMock
+                .Setup(manager => manager.FindByIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ApplicationUser());
+
+            _userManagerMock
+                .Setup(manager => manager.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+                .ReturnsAsync(Microsoft.AspNetCore.Identity.IdentityResult.Failed());
+
+            var result = await _accountController.ConfirmEmail("1234", "test_code");
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("Error", viewResult.ViewName);
+        }
+
+        [Fact]
+        public void ForgotPassword_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.ForgotPassword();
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public void ForgotPasswordConfirmation_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.ForgotPasswordConfirmation();
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public void ResetPassword_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.ResetPassword("test_code");
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<ResetPasswordViewModel>(viewResult.Model);
+
+            Assert.Equal("test_code", model.Code);
+        }
+
+        [Fact]
+        public async Task PostResetPassword_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            _userManagerMock
+                .Setup(manager => manager.FindByEmailAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ApplicationUser());
+
+            _userManagerMock
+                .Setup(manager => manager.ResetPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var result = await _accountController.ResetPassword(
+                new ResetPasswordViewModel { Email = "max@example.com", Code = "test_code", Password = "abcDEF123_" });
+            var actionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("ResetPasswordConfirmation", actionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostResetPassword_ReturnsRedirectToActionResult_WhenModelStateIsNotValid()
+        {
+            _accountController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _accountController.ResetPassword(new ResetPasswordViewModel());
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ResetPasswordViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task PostResetPassword_ReturnsRedirectToActionResult_WhenCanNotFindUserByEmail()
+        {
+            _userManagerMock
+                .Setup(manager => manager.FindByEmailAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => null);
+
+            var result = await _accountController.ResetPassword(
+                new ResetPasswordViewModel { Email = "max@example.com"});
+            var actionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("ResetPasswordConfirmation", actionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostResetPassword_ReturnsViewResult_WithErrors_WhenIsFailed()
+        {
+            _userManagerMock
+                .Setup(manager => manager.FindByEmailAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ApplicationUser());
+
+            _userManagerMock
+                .Setup(manager => manager.ResetPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "01", Description = "Test error" }));
+
+            var result = await _accountController.ResetPassword(
+                new ResetPasswordViewModel { Email = "max@example.com", Code = "test_code", Password = "abcDEF123_" });
+
+            Assert.IsType<ViewResult>(result);
+            Assert.False(_accountController.ModelState.IsValid);
+            Assert.Equal(1, _accountController.ModelState.Count);
+        }
+
+        [Fact]
+        public void ResetPasswordConfirmation_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.ResetPasswordConfirmation();
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public void AccessDenied_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _accountController.AccessDenied();
+
+            Assert.IsType<ViewResult>(result);
+        }
+    }
+}

--- a/Amoraitis.Todo.UnitTests/Controllers/HomeControllerTest.cs
+++ b/Amoraitis.Todo.UnitTests/Controllers/HomeControllerTest.cs
@@ -1,0 +1,75 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Amoraitis.Todo.UnitTests.Resources;
+using Amoraitis.TodoList.Controllers;
+using Amoraitis.TodoList.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Amoraitis.Todo.UnitTests.Controllers
+{
+    public class HomeControllerTest
+    {
+        private Mock<FakeUserManager> _userManagerMock;
+        private HomeController _homeController;
+
+        public HomeControllerTest()
+        {
+            _userManagerMock =  new Mock<FakeUserManager>();
+            _homeController = new HomeController(_userManagerMock.Object);
+
+            _homeController.ControllerContext = new ControllerContext();
+            _homeController.ControllerContext.HttpContext = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = await _homeController.Index();
+            var viewResult = Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Index_ReturnsRedirectToActionResult_WhenFindAUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser());
+
+            var result = await _homeController.Index();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("Home", redirectToActionResult.ActionName);
+            Assert.Equal("Todos", redirectToActionResult.ControllerName);
+        }
+
+        [Fact]
+        public void About_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _homeController.About();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("Your application description page.", viewResult.ViewData["Message"]);
+        }
+
+        [Fact]
+        public void Contact_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _homeController.Contact();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("Your contact page.", viewResult.ViewData["Message"]);
+        }
+
+        [Fact]
+        public void Error_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _homeController.Error();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ErrorViewModel>(viewResult.Model);
+        }
+    }
+}

--- a/Amoraitis.Todo.UnitTests/Controllers/ManageControllerTest.cs
+++ b/Amoraitis.Todo.UnitTests/Controllers/ManageControllerTest.cs
@@ -1,0 +1,899 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Amoraitis.Todo.UnitTests.Resources;
+using Amoraitis.TodoList.Controllers;
+using Amoraitis.TodoList.Models;
+using Amoraitis.TodoList.Models.ManageViewModels;
+using Amoraitis.TodoList.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Amoraitis.Todo.UnitTests.Controllers
+{
+    public class ManageControllerTest
+    {
+        private Mock<FakeUserManager> _userManagerMock;
+        private Mock<FakeSignInManager> _signInManagerMock;
+        private Mock<IEmailSender> _emailSenderMock;
+        private Mock<UrlEncoder> _urlEncoderMock;
+        private Mock<ILogger<ManageController>> _loggerMock;
+        private ManageController _manageController;
+
+        public ManageControllerTest()
+        {
+            _userManagerMock =  new Mock<FakeUserManager>();
+            _signInManagerMock = new Mock<FakeSignInManager>();
+            _emailSenderMock =  new Mock<IEmailSender>();
+            _urlEncoderMock =  new Mock<UrlEncoder>();
+            _loggerMock = new Mock<ILogger<ManageController>>();
+
+            _manageController = new ManageController(_userManagerMock.Object,
+                    _signInManagerMock.Object,
+                    _emailSenderMock.Object,
+                    _loggerMock.Object,
+                    _urlEncoderMock.Object);
+
+            _manageController.ControllerContext = new ControllerContext();
+            _manageController.ControllerContext.HttpContext = new DefaultHttpContext();
+
+            var authManager = new Mock<IAuthenticationService>();
+
+            authManager.Setup(service => service.SignOutAsync(It.IsAny<HttpContext>(),
+                It.IsAny<string>(),
+                It.IsAny<AuthenticationProperties>()))
+                .Returns(Task.FromResult(true));
+
+            var servicesMock = new Mock<IServiceProvider>();
+
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IAuthenticationService)))
+                .Returns(authManager.Object);
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IUrlHelperFactory)))
+                .Returns(new UrlHelperFactory());
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(ITempDataDictionaryFactory)))
+                .Returns(new TempDataDictionaryFactory(new SessionStateTempDataProvider()));
+            servicesMock.Setup(serviceProvider => serviceProvider.GetService(typeof(IPrincipal)))
+                .Returns(new ClaimsPrincipal());
+
+            _manageController.ControllerContext.HttpContext.RequestServices = servicesMock.Object;
+            _manageController.ControllerContext.HttpContext.Session = Mock.Of<ISession>();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            var result = await _manageController.Index();
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<IndexViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task Index_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Index());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostIndex_ReturnsRedirectToActionResult_WhenSucceed()
+        {
+            var user = new ApplicationUser { Email = "max@example.com", PhoneNumber = "1-800-555-5555" };
+            var model = new IndexViewModel { Email = "newmail@example.com", PhoneNumber = "1-800-777-7777" };
+
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(user);
+
+            _userManagerMock
+                .Setup(manager => manager.SetEmailAsync(user, model.Email))
+                .ReturnsAsync(IdentityResult.Success);
+
+            _userManagerMock
+                .Setup(manager => manager.SetPhoneNumberAsync(user, model.PhoneNumber))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var result = await _manageController.Index(model);
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("Your profile has been updated", _manageController.StatusMessage);
+            Assert.Equal("Index", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostIndex_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _manageController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _manageController.Index(new IndexViewModel());
+
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<IndexViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task PostIndex_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Index(new IndexViewModel()));
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostIndex_ThrowsApplicationException_WhenCanNotSetEmail()
+        {
+            var user = new ApplicationUser { Email = "max@example.com", Id = "1" };
+            var model = new IndexViewModel { Email = "newmail@example.com" };
+
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(user);
+
+            _userManagerMock
+                .Setup(manager => manager.SetEmailAsync(user, model.Email))
+                .ReturnsAsync(IdentityResult.Failed());
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Index(model));
+
+            Assert.Equal("Unexpected error occurred setting email for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostIndex_ThrowsApplicationException_WhenCanNotSetPhoneNumber()
+        {
+            var user = new ApplicationUser { Email = "max@example.com", PhoneNumber = "1-800-555-5555", Id = "1" };
+            var model = new IndexViewModel { Email = "max@example.com", PhoneNumber = "1-800-777-7777" };
+
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(user);
+
+            _userManagerMock
+                .Setup(manager => manager.SetPhoneNumberAsync(user, model.PhoneNumber))
+                .ReturnsAsync(IdentityResult.Failed());
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Index(model));
+
+            Assert.Equal("Unexpected error occurred setting phone number for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task ChangePassword_ReturnsViewResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.HasPasswordAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            var result = await _manageController.ChangePassword();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ChangePasswordViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task ChangePassword_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.ChangePassword());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task ChangePassword_ReturnsRedirectToActionResult_WhenUserHasNoPassword()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.HasPasswordAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(false);
+
+            var result = await _manageController.ChangePassword();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("SetPassword", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostChangePassword_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            var model = new ChangePasswordViewModel { OldPassword = "1234", NewPassword = "abcDEF123_" };
+
+            SetGetUserAsyncMethod();
+
+            _signInManagerMock
+                .Setup(manager => manager.SignInAsync(It.IsAny<ApplicationUser>(), false, null))
+                .Returns(Task.CompletedTask);
+
+            _userManagerMock
+                .Setup(manager => manager.ChangePasswordAsync(It.IsAny<ApplicationUser>(), model.OldPassword, model.NewPassword))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var result = await _manageController.ChangePassword(model);
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("Your password has been changed.", _manageController.StatusMessage);
+            Assert.Equal("ChangePassword", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostChangePassword_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _manageController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _manageController.ChangePassword(new ChangePasswordViewModel());
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ChangePasswordViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task PostChangePassword_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.ChangePassword(new ChangePasswordViewModel()));
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostChangePassword_ReturnsViewResult_WhenCanNotChangePassword()
+        {
+            var model = new ChangePasswordViewModel { OldPassword = "1234", NewPassword = "abcDEF123_" };
+
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.ChangePasswordAsync(It.IsAny<ApplicationUser>(), model.OldPassword, model.NewPassword))
+                .ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "01", Description = "Test error" }));
+
+            var result = await _manageController.ChangePassword(model);
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ChangePasswordViewModel>(viewResult.Model);
+            Assert.Equal(1, _manageController.ModelState.Count);
+        }
+
+        [Fact]
+        public async Task SetPassword_ReturnsViewResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            var result = await _manageController.SetPassword();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<SetPasswordViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task SetPassword_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.SetPassword());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task SetPassword_ReturnsRedirectToActionResult_WhenUserHasPassword()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.HasPasswordAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            var result = await _manageController.SetPassword();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("ChangePassword", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostSetPassword_RedirectToActionResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.AddPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Success);
+
+            _signInManagerMock
+                .Setup(manager => manager.SignInAsync(It.IsAny<ApplicationUser>(), false, null))
+                .Returns(Task.CompletedTask);
+
+            var result = await _manageController.SetPassword(new SetPasswordViewModel{ NewPassword = "abcDEF123_" });
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("Your password has been set.", _manageController.StatusMessage);
+            Assert.Equal("SetPassword", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostSetPassword_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _manageController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _manageController.SetPassword(new SetPasswordViewModel{ NewPassword = "abcDEF123_" });
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<SetPasswordViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task PostSetPassword_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.SetPassword(new SetPasswordViewModel()));
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostSetPassword_ReturnsViewResult_WhenCanNotAddPassword()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.AddPasswordAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Failed(new IdentityError { Code = "01", Description = "Test error" }));
+
+            var result = await _manageController.SetPassword(new SetPasswordViewModel{ NewPassword = "abcDEF123_" });
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<SetPasswordViewModel>(viewResult.Model);
+            Assert.Equal(1, _manageController.ModelState.Count);
+        }
+
+        [Fact]
+        public async Task ExternalLogins_ReturnsViewResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.HasPasswordAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            var result = await _manageController.ExternalLogins();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ExternalLoginsViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task ExternalLogins_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.ExternalLogins());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task LinkLoginCallback_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
+                .ReturnsAsync(IdentityResult.Success);
+
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ExternalLoginInfo(new ClaimsPrincipal(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            var result = await _manageController.LinkLoginCallback();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("The external login was added.", _manageController.StatusMessage);
+            Assert.Equal("ExternalLogins", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task LinkLoginCallback_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.LinkLoginCallback());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task LinkLoginCallback_ThrowsApplicationException_WhenCanNotGetExternalLoginInfo()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ Id = "1" });
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.LinkLoginCallback());
+
+            Assert.Equal("Unexpected error occurred loading external login info for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task LinkLoginCallback_ThrowsApplicationException_WhenCanNotAddLogin()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ Id = "1" });
+
+            _userManagerMock
+                .Setup(manager => manager.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
+                .ReturnsAsync(IdentityResult.Failed());
+
+            _signInManagerMock
+                .Setup(manager => manager.GetExternalLoginInfoAsync(It.IsAny<string>()))
+                .ReturnsAsync(new ExternalLoginInfo(new ClaimsPrincipal(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()));
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.LinkLoginCallback());
+
+            Assert.Equal("Unexpected error occurred adding external login for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task RemoveLogin_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.RemoveLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var result = await _manageController.RemoveLogin(new RemoveLoginViewModel {
+                LoginProvider = "Test provider", ProviderKey = "Test key"
+            });
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("The external login was removed.", _manageController.StatusMessage);
+            Assert.Equal("ExternalLogins", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task RemoveLogin_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.RemoveLogin(new RemoveLoginViewModel()));
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task RemoveLogin_ThrowsApplicationException_WhenCanNotRemoveLogin()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ Id = "1" });
+
+            _userManagerMock
+                .Setup(manager => manager.RemoveLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(IdentityResult.Failed());
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.RemoveLogin(new RemoveLoginViewModel()));
+
+            Assert.Equal("Unexpected error occurred removing external login for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task TwoFactorAuthentication_ReturnsViewResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            var result = await _manageController.TwoFactorAuthentication();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<TwoFactorAuthenticationViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task TwoFactorAuthentication_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.TwoFactorAuthentication());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task Disable2faWarning_ReturnsViewResult_WhenSucceeded()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ TwoFactorEnabled = true });
+
+            var result = await _manageController.Disable2faWarning();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("Disable2fa", viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task Disable2faWarning_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Disable2faWarning());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task Disable2faWarning_ThrowsApplicationException_WhenUserDoesNotHaveTwoFactorEnabled()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ Id = "1", TwoFactorEnabled = false });
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Disable2faWarning());
+
+            Assert.Equal("Unexpected error occured disabling 2FA for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task Disable2fa_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(manager => manager.SetTwoFactorEnabledAsync(It.IsAny<ApplicationUser>(), false))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var result = await _manageController.Disable2fa();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("TwoFactorAuthentication", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task Disable2fa_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Disable2fa());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task Disable2fa_ThrowsApplicationException_WhenCanNotSetTwoFactor()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ Id = "1" });
+
+            _userManagerMock
+                .Setup(manager => manager.SetTwoFactorEnabledAsync(It.IsAny<ApplicationUser>(), false))
+                .ReturnsAsync(IdentityResult.Failed());
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.Disable2fa());
+
+            Assert.Equal("Unexpected error occured disabling 2FA for user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task EnableAuthenticator_ReturnsViewResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(ManageUsersController=> ManageUsersController.GetAuthenticatorKeyAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync("test_string");
+
+            var result = await _manageController.EnableAuthenticator();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<EnableAuthenticatorViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task EnableAuthenticator_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.EnableAuthenticator());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostEnableAuthenticator_ReturnsRedirectToActionResult_WhenSucceeded()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(ManageUsersController => ManageUsersController.GetAuthenticatorKeyAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync("test_string");
+
+            _userManagerMock
+                .Setup(ManageUsersController =>
+                    ManageUsersController.VerifyTwoFactorTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            _userManagerMock
+                .Setup(ManageUsersController =>
+                    ManageUsersController.GenerateNewTwoFactorRecoveryCodesAsync(It.IsAny<ApplicationUser>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<string>());
+
+            var result = await _manageController.EnableAuthenticator(new EnableAuthenticatorViewModel{ Code = "Test code" });
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("ShowRecoveryCodes", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task PostEnableAuthenticator_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.EnableAuthenticator(new EnableAuthenticatorViewModel()));
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task PostEnableAuthenticator_ReturnsViewResult_WhenModelStateIsNotValid()
+        {
+            _manageController.ModelState.AddModelError("Test error", "Test error");
+
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(ManageUsersController => ManageUsersController.GetAuthenticatorKeyAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync("test_string");
+
+            _userManagerMock
+                .Setup(ManageUsersController =>
+                    ManageUsersController.VerifyTwoFactorTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            var result = await _manageController.EnableAuthenticator(new EnableAuthenticatorViewModel{ Code = "test code" });
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<EnableAuthenticatorViewModel>(viewResult.Model);
+        }
+
+        [Fact]
+        public async Task PostEnableAuthenticator_ReturnsViewResult_WithErrors_WhenCanNotVerifyTwoFactorToken()
+        {
+            SetGetUserAsyncMethod();
+
+            _userManagerMock
+                .Setup(ManageUsersController => ManageUsersController.GetAuthenticatorKeyAsync(It.IsAny<ApplicationUser>()))
+                .ReturnsAsync("test_string");
+
+            _userManagerMock
+                .Setup(ManageUsersController =>
+                    ManageUsersController.VerifyTwoFactorTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            var result = await _manageController.EnableAuthenticator(new EnableAuthenticatorViewModel{ Code = "test code" });
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<EnableAuthenticatorViewModel>(viewResult.Model);
+            Assert.Equal(1, _manageController.ModelState.Count);
+        }
+
+        [Fact]
+        public void ShowRecoveryCodes_ReturnsViewResult_WhenSucceeded()
+        {
+            string[] recoveryCodes = new string[] { "test code 1", "test code 2", "test code 3" };
+            _manageController.TempData["RecoveryCodesKey"] = recoveryCodes;
+
+            var result = _manageController.ShowRecoveryCodes();
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var viewModel = Assert.IsAssignableFrom<ShowRecoveryCodesViewModel>(viewResult.Model);
+
+            Assert.Equal(recoveryCodes, viewModel.RecoveryCodes);
+        }
+
+        [Fact]
+        public void ShowRecoveryCodes_ReturnsRedirectToActionResult_WhenTempDataDoesNotHaveRecoveryCodes()
+        {
+            var result = _manageController.ShowRecoveryCodes();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("TwoFactorAuthentication", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public void ResetAuthenticatorWarning_ReturnsViewResult_WhenSucceeded()
+        {
+            var result = _manageController.ResetAuthenticatorWarning();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("ResetAuthenticator", viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task ResetAuthenticator_ReturnsRedirectToActionResult_WhenSucceded()
+        {
+            SetGetUserAsyncMethod();
+
+            var result = await _manageController.ResetAuthenticator();
+            var redirectToActionResult = Assert.IsType<RedirectToActionResult>(result);
+
+            Assert.Equal("EnableAuthenticator", redirectToActionResult.ActionName);
+        }
+
+        [Fact]
+        public async Task ResetAuthenticator_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.ResetAuthenticator());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task GenerateRecoveryCodesWarning_ReturnsViewResult_WhenSucceeded()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ TwoFactorEnabled = true });
+
+            var result = await _manageController.GenerateRecoveryCodesWarning();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("GenerateRecoveryCodes", viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task GenerateRecoveryCodesWarning_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.GenerateRecoveryCodesWarning());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task GenerateRecoveryCodesWarning_ThrowsApplicationException_WhenUserDoesNotHaveTwoFactorEnabled()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ TwoFactorEnabled = false, Id = "1" });
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.GenerateRecoveryCodesWarning());
+
+            Assert.Equal("Cannot generate recovery codes for user with ID '1' because they do not have 2FA enabled.", exception.Message);
+        }
+
+        [Fact]
+        public async Task GenerateRecoveryCodes_ReturnsViewResult_WhenSucceeded()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ TwoFactorEnabled = true });
+
+            _userManagerMock
+                .Setup(ManageUsersController =>
+                    ManageUsersController.GenerateNewTwoFactorRecoveryCodesAsync(It.IsAny<ApplicationUser>(), It.IsAny<int>()))
+                .ReturnsAsync(new List<string>());
+
+            var result = await _manageController.GenerateRecoveryCodes();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ShowRecoveryCodesViewModel>(viewResult.Model);
+            Assert.Equal("ShowRecoveryCodes", viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task GenerateRecoveryCodes_ThrowsApplicationException_WhenCanNotFindUser()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserId(It.IsAny<ClaimsPrincipal>()))
+                .Returns("1");
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.GenerateRecoveryCodes());
+
+            Assert.Equal("Unable to load user with ID '1'.", exception.Message);
+        }
+
+        [Fact]
+        public async Task GenerateRecoveryCodes_ThrowsApplicationException_WhenUserDoesNotHaveTwoFactorEnabled()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser{ TwoFactorEnabled = false, Id = "1" });
+
+            var exception = await Assert.ThrowsAsync<ApplicationException>(
+                async () => await _manageController.GenerateRecoveryCodes());
+
+            Assert.Equal("Cannot generate recovery codes for user with ID '1' as they do not have 2FA enabled.", exception.Message);
+        }
+
+        private void SetGetUserAsyncMethod()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser());
+        }
+    }
+}

--- a/Amoraitis.Todo.UnitTests/Controllers/ManageUsersControllerTest.cs
+++ b/Amoraitis.Todo.UnitTests/Controllers/ManageUsersControllerTest.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using Amoraitis.Todo.UnitTests.Resources;
+using Amoraitis.TodoList;
+using Amoraitis.TodoList.Controllers;
+using Amoraitis.TodoList.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Amoraitis.Todo.UnitTests.Controllers
+{
+    public class ManageUsersControllerTest
+    {
+        private Mock<FakeUserManager> _userManagerMock;
+        private ManageUsersController _manageUsersController;
+
+        public ManageUsersControllerTest()
+        {
+            _userManagerMock =  new Mock<FakeUserManager>();
+            _manageUsersController = new ManageUsersController(_userManagerMock.Object);
+
+            _manageUsersController.ControllerContext = new ControllerContext();
+            _manageUsersController.ControllerContext.HttpContext = new DefaultHttpContext();
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WhenSucceeded()
+        {
+            _userManagerMock
+                .Setup(manager => manager.GetUsersInRoleAsync(Constants.AdministratorRole))
+                .ReturnsAsync(new ApplicationUser[] { new ApplicationUser{ Id = "1" } });
+
+            _userManagerMock
+                .Setup(manager => manager.GetUsersInRoleAsync(Constants.UserRole))
+                .ReturnsAsync(new ApplicationUser[] { new ApplicationUser{ Id = "2" } });
+
+            var result = await _manageUsersController.Index();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<ManageUsersViewModel>(viewResult.Model);
+        }
+    }
+}

--- a/Amoraitis.Todo.UnitTests/Controllers/TodosControllerTest.cs
+++ b/Amoraitis.Todo.UnitTests/Controllers/TodosControllerTest.cs
@@ -1,0 +1,385 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Amoraitis.Todo.UnitTests.Resources;
+using Amoraitis.TodoList.Controllers;
+using Amoraitis.TodoList.Models;
+using Amoraitis.TodoList.Services;
+using Amoraitis.TodoList.Services.Storage;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Amoraitis.Todo.UnitTests.Controllers
+{
+    public class TodosControllerTest
+    {
+        private Mock<ITodoItemService> _todoItemServiceMock;
+        private Mock<IFileStorageService> _fileItemServiceMock;
+        private Mock<FakeUserManager> _userManagerMock;
+
+        private TodosController _todosController;
+
+        public TodosControllerTest()
+        {
+            this._todoItemServiceMock = new Mock<ITodoItemService>();
+            this._fileItemServiceMock = new Mock<IFileStorageService>();
+            this._userManagerMock =  new Mock<FakeUserManager>();
+
+            this._userManagerMock
+                .Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(new ApplicationUser { UserName = "Max", Email = "max@example.com" });
+
+            this._todosController = new TodosController(this._todoItemServiceMock.Object,
+                        this._userManagerMock.Object,
+                        this._fileItemServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task Home_ReturnsViewResult_WithRecenttlyAddedAndCloseTodos()
+        {
+            var result = await _todosController.Home();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<HomeViewModel>(viewResult.ViewData.Model);
+        }
+
+        [Fact]
+        public async Task Home_ReturnsChallengeResult_WhenUserIsNull()
+        {
+            SetupGetUserAsyncToNull();
+
+            var result = await _todosController.Home();
+
+            Assert.IsType<ChallengeResult>(result);
+        }
+
+        [Fact]
+        public async Task Index_ReturnsViewResult_WithAListOfTodosAndDones()
+        {
+            var result = await _todosController.Index();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<TodoViewModel>(viewResult.ViewData.Model);
+        }
+
+        [Fact]
+        public async Task Index_ReturnsChallengeResult_WhenUserIsNull()
+        {
+            SetupGetUserAsyncToNull();
+
+            var result = await _todosController.Index();
+
+            Assert.IsType<ChallengeResult>(result);
+        }
+
+        [Fact]
+        public void Create_ReturnsViewResult()
+        {
+            var result = _todosController.Create();
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Null(viewResult.ViewName);
+        }
+
+        [Fact]
+        public async Task Create_RedirectsToIndex_WhenTodoItemIsCreated()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.AddItemAsync(It.IsAny<TodoItem>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            var result = await _todosController.Create(new TodoItem {
+                Id = new Guid(),
+                Title = "Test title",
+                Content = "Test content",
+                DuetoDateTime = DateTime.Now
+            });
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsBadRequestObjectResult_WhenTodoItemIsNotCreated()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.AddItemAsync(It.IsAny<TodoItem>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(false);
+
+            var result = await _todosController.Create(new TodoItem {
+                Id = new Guid(),
+                Title = "Test title",
+                Content = "Test content",
+                DuetoDateTime = DateTime.Now
+            });
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_RedirectsToIndex_WhenTodoItemIsInvalid()
+        {
+
+            _todosController.ModelState.AddModelError("Test error", "Test error");
+
+            var result = await _todosController.Create(new TodoItem {
+                Id = new Guid(),
+                Title = "Test title",
+                Content = "Test content",
+                DuetoDateTime = DateTime.Now
+            });
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task UpdateDone_RedirectsToIndex_WhenTodoItemIsUpdated()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.UpdateDoneAsync(It.IsAny<Guid>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            var result = await _todosController.UpdateDone(Guid.NewGuid());
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task UpdateDone_RedirectsToIndex_WhenGuidIsEmpty()
+        {
+            var result = await _todosController.UpdateDone(Guid.Empty);
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task UpdateDone_ReturnsChallengeResult_WhenUserIsNull()
+        {
+            SetupGetUserAsyncToNull();
+
+            var result = await _todosController.UpdateDone(Guid.NewGuid());
+
+            Assert.IsType<ChallengeResult>(result);
+        }
+
+        [Fact]
+        public async Task UpdateDone_ReturnsBadRequestObjectResult_WhenTodoItemCanNotBeUpdated()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.UpdateDoneAsync(It.IsAny<Guid>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(false);
+
+            var result = await _todosController.UpdateDone(Guid.NewGuid());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Could not update todo.", (result as BadRequestObjectResult).Value.ToString());
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsViewResult_WhenValidGuid()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.GetItemAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new TodoItem());
+
+            var result = await _todosController.Edit(Guid.NewGuid());
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<EditViewModel>(viewResult.ViewData.Model);
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsNotFoundResult_WhenGuidIsEmpty()
+        {
+            var result = await _todosController.Edit(Guid.Empty);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Edit_ReturnsNotFoundResult_WhenTodoItemCanNotBeFound()
+        {
+            SetupGetUserAsyncToNull();
+
+            var result = await _todosController.Edit(Guid.NewGuid());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task PostEdit_RedirectsToIndex_WhenTodoItemIsUpdated()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.UpdateTodoAsync(It.IsAny<TodoItem>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            var result = await _todosController.Edit(Guid.NewGuid(), new EditViewModel());
+
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", (result as RedirectToActionResult).ActionName);
+        }
+
+        [Fact]
+        public async Task PostEdit_ReturnsNotFoundResult_WhenGuidIsEmpty()
+        {
+            var result = await _todosController.Edit(Guid.Empty, new EditViewModel());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task PostEdit_ReturnsBadRequestObjectResult_WhenTodoCanNotBeUpdated()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.UpdateTodoAsync(It.IsAny<TodoItem>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(false);
+
+            var result = await _todosController.Edit(Guid.NewGuid(), new EditViewModel());
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Could not update todo.", (result as BadRequestObjectResult).Value.ToString());
+        }
+
+        [Fact]
+        public async Task Details_ReturnsViewResult_WhenGuidIsValid()
+        {
+            TodoItem todo = new TodoItem();
+            todo.File = new FileInfo();
+            todo.File.Path = "/fake/path/fake_file.txt";
+
+            this._todoItemServiceMock
+                .Setup(service => service.GetItemAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(todo);
+
+            var result = await _todosController.Details(Guid.NewGuid());
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.Equal("fake_file.txt", viewResult.ViewData["Filename"]);
+        }
+
+        [Fact]
+        public async Task Details_ReturnsNotFoundResult_WhenGuidIsEmpty()
+        {
+            var result = await _todosController.Details(Guid.Empty);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Details_ReturnsNotFoundResult_WhenTodoItemCanNotBeFound()
+        {
+            SetupGetUserAsyncToNull();
+
+            var result = await _todosController.Details(Guid.NewGuid());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsViewResult_WhenGuidIsValid()
+        {
+            TodoItem todo = new TodoItem();
+            todo.File = new FileInfo();
+            todo.File.Path = "/fake/path/fake_file.txt";
+
+            this._todoItemServiceMock
+                .Setup(service => service.GetItemAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(todo);
+
+            var result = await _todosController.Delete(Guid.NewGuid());
+            var viewResult = Assert.IsType<ViewResult>(result);
+
+            Assert.IsAssignableFrom<DeleteViewModel>(viewResult.ViewData.Model);
+            Assert.Equal("fake_file.txt", viewResult.ViewData["Filename"]);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNotFoundResult_WhenGuidIsEmpty()
+        {
+            var result = await _todosController.Delete(Guid.Empty);
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task Delete_ReturnsNotFoundResult_WhenTodoItemCanNotBeFound()
+        {
+            SetupGetUserAsyncToNull();
+
+            var result = await _todosController.Delete(Guid.NewGuid());
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsRedirectToActionResult_WhenTodoItemIsDeleted()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.DeleteTodoAsync(It.IsAny<Guid>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            this._fileItemServiceMock
+                .Setup(service => service.DeleteFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            var result = await _todosController.DeleteConfirmed(Guid.NewGuid(), "");
+
+            Assert.IsType<RedirectToActionResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsNotFoundResult_WhenGuidIsEmpty()
+        {
+            var result = await _todosController.DeleteConfirmed(Guid.Empty, "");
+
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsBadRequestObjectResult_WhenCanNotDeleteTodoItem()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.DeleteTodoAsync(It.IsAny<Guid>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(false);
+
+            var result = await _todosController.DeleteConfirmed(Guid.NewGuid(), "");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(
+                new { error = "Couldn't delete item!" }.ToString(),
+                (result as BadRequestObjectResult).Value.ToString()
+            );
+        }
+
+        [Fact]
+        public async Task DeleteConfirmed_ReturnsBadRequestObjectResult_WhenCanNotDeleteFile()
+        {
+            this._todoItemServiceMock
+                .Setup(service => service.DeleteTodoAsync(It.IsAny<Guid>(), It.IsAny<ApplicationUser>()))
+                .ReturnsAsync(true);
+
+            this._fileItemServiceMock
+                .Setup(service => service.DeleteFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            var result = await _todosController.DeleteConfirmed(Guid.NewGuid(), "");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal(
+                new { error = "Couldn't delete item!" }.ToString(),
+                (result as BadRequestObjectResult).Value.ToString()
+            );
+        }
+
+        private void SetupGetUserAsyncToNull()
+        {
+            this._userManagerMock
+                .Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>()))
+                .ReturnsAsync(() => null);
+        }
+    }
+}

--- a/Amoraitis.Todo.UnitTests/Resources/FakeSignInManager.cs
+++ b/Amoraitis.Todo.UnitTests/Resources/FakeSignInManager.cs
@@ -1,0 +1,23 @@
+using System;
+using Amoraitis.TodoList.Models;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Amoraitis.Todo.UnitTests.Resources
+{
+    public class FakeSignInManager : SignInManager<ApplicationUser>
+    {
+        public FakeSignInManager()
+            : base(new FakeUserManager(),
+            new Mock<IHttpContextAccessor>().Object,
+            new Mock<IUserClaimsPrincipalFactory<ApplicationUser>>().Object,
+            new Mock<IOptions<IdentityOptions>>().Object,
+            new Mock<ILogger<SignInManager<ApplicationUser>>>().Object,
+            new Mock<IAuthenticationSchemeProvider>().Object)
+        { }
+    }
+}

--- a/Amoraitis.Todo.UnitTests/Resources/FakeUserManager.cs
+++ b/Amoraitis.Todo.UnitTests/Resources/FakeUserManager.cs
@@ -1,0 +1,24 @@
+using System;
+using Amoraitis.TodoList.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Amoraitis.Todo.UnitTests.Resources
+{
+    public class FakeUserManager : UserManager<ApplicationUser>
+    {
+        public FakeUserManager()
+            : base(new Mock<IUserStore<ApplicationUser>>().Object,
+                  new Mock<IOptions<IdentityOptions>>().Object,
+                  new Mock<IPasswordHasher<ApplicationUser>>().Object,
+                  new IUserValidator<ApplicationUser>[0],
+                  new IPasswordValidator<ApplicationUser>[0],
+                  new Mock<ILookupNormalizer>().Object,
+                  new Mock<IdentityErrorDescriber>().Object,
+                  new Mock<IServiceProvider>().Object,
+                  new Mock<ILogger<UserManager<ApplicationUser>>>().Object)
+        { }
+    }
+}

--- a/Amoraitis.TodoList/Controllers/AccountController.cs
+++ b/Amoraitis.TodoList/Controllers/AccountController.cs
@@ -74,7 +74,7 @@ namespace Amoraitis.TodoList.Controllers
                 }
                 else
                 {
-                    ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+                    ModelState.AddModelError("INVALID_LOGIN_ATTEMPT", "Invalid login attempt.");
                     return View(model);
                 }
             }
@@ -134,7 +134,7 @@ namespace Amoraitis.TodoList.Controllers
             else
             {
                 _logger.LogWarning("Invalid authenticator code entered for user with ID {UserId}.", user.Id);
-                ModelState.AddModelError(string.Empty, "Invalid authenticator code.");
+                ModelState.AddModelError("INVALID_AUTHENTICATOR_CODE", "Invalid authenticator code.");
                 return View();
             }
         }
@@ -188,7 +188,7 @@ namespace Amoraitis.TodoList.Controllers
             else
             {
                 _logger.LogWarning("Invalid recovery code entered for user with ID {UserId}", user.Id);
-                ModelState.AddModelError(string.Empty, "Invalid recovery code entered.");
+                ModelState.AddModelError("INVALID_RECOVERY_CODE", "Invalid recovery code entered.");
                 return View();
             }
         }

--- a/Amoraitis.TodoList/Controllers/ManageController.cs
+++ b/Amoraitis.TodoList/Controllers/ManageController.cs
@@ -47,11 +47,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> Index()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var model = new IndexViewModel
             {
@@ -74,11 +70,7 @@ namespace Amoraitis.TodoList.Controllers
                 return View(model);
             }
 
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var email = user.Email;
             if (model.Email != email)
@@ -113,11 +105,7 @@ namespace Amoraitis.TodoList.Controllers
                 return View(model);
             }
 
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
             var callbackUrl = Url.EmailConfirmationLink(user.Id, code, Request.Scheme);
@@ -131,11 +119,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> ChangePassword()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var hasPassword = await _userManager.HasPasswordAsync(user);
             if (!hasPassword)
@@ -156,11 +140,7 @@ namespace Amoraitis.TodoList.Controllers
                 return View(model);
             }
 
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var changePasswordResult = await _userManager.ChangePasswordAsync(user, model.OldPassword, model.NewPassword);
             if (!changePasswordResult.Succeeded)
@@ -179,11 +159,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> SetPassword()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var hasPassword = await _userManager.HasPasswordAsync(user);
 
@@ -205,11 +181,7 @@ namespace Amoraitis.TodoList.Controllers
                 return View(model);
             }
 
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var addPasswordResult = await _userManager.AddPasswordAsync(user, model.NewPassword);
             if (!addPasswordResult.Succeeded)
@@ -227,11 +199,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> ExternalLogins()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var model = new ExternalLoginsViewModel { CurrentLogins = await _userManager.GetLoginsAsync(user) };
             model.OtherLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync())
@@ -259,11 +227,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> LinkLoginCallback()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var info = await _signInManager.GetExternalLoginInfoAsync(user.Id);
             if (info == null)
@@ -288,11 +252,7 @@ namespace Amoraitis.TodoList.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> RemoveLogin(RemoveLoginViewModel model)
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var result = await _userManager.RemoveLoginAsync(user, model.LoginProvider, model.ProviderKey);
             if (!result.Succeeded)
@@ -308,11 +268,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> TwoFactorAuthentication()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var model = new TwoFactorAuthenticationViewModel
             {
@@ -327,11 +283,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> Disable2faWarning()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             if (!user.TwoFactorEnabled)
             {
@@ -345,11 +297,7 @@ namespace Amoraitis.TodoList.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Disable2fa()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var disable2faResult = await _userManager.SetTwoFactorEnabledAsync(user, false);
             if (!disable2faResult.Succeeded)
@@ -364,11 +312,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> EnableAuthenticator()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             var model = new EnableAuthenticatorViewModel();
             await LoadSharedKeyAndQrCodeUriAsync(user, model);
@@ -380,11 +324,7 @@ namespace Amoraitis.TodoList.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> EnableAuthenticator(EnableAuthenticatorViewModel model)
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             if (!ModelState.IsValid)
             {
@@ -436,11 +376,7 @@ namespace Amoraitis.TodoList.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> ResetAuthenticator()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             await _userManager.SetTwoFactorEnabledAsync(user, false);
             await _userManager.ResetAuthenticatorKeyAsync(user);
@@ -452,11 +388,7 @@ namespace Amoraitis.TodoList.Controllers
         [HttpGet]
         public async Task<IActionResult> GenerateRecoveryCodesWarning()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             if (!user.TwoFactorEnabled)
             {
@@ -470,11 +402,7 @@ namespace Amoraitis.TodoList.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> GenerateRecoveryCodes()
         {
-            var user = await _userManager.GetUserAsync(User);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
+            var user = await GetUserOrFail();
 
             if (!user.TwoFactorEnabled)
             {
@@ -514,6 +442,18 @@ namespace Amoraitis.TodoList.Controllers
             }
 
             return result.ToString().ToLowerInvariant();
+        }
+
+        private async Task<ApplicationUser> GetUserOrFail()
+        {
+            var user = await _userManager.GetUserAsync(User);
+
+            if (user == null)
+            {
+                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+            return user;
         }
 
         private string GenerateQrCodeUri(string email, string unformattedKey)

--- a/Amoraitis.TodoList/Controllers/TodosController.cs
+++ b/Amoraitis.TodoList/Controllers/TodosController.cs
@@ -63,10 +63,10 @@ namespace Amoraitis.TodoList.Controllers
         }
 
         // GET: Todos/Create
-        public async Task<IActionResult> Create() => View();
+        public ViewResult Create() => View();
 
         // POST: Todos/Create
-        // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
+        // To protect from overposting attacks, please enable the specific properties you want to bind to, for
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
@@ -214,6 +214,9 @@ namespace Amoraitis.TodoList.Controllers
             if (id == Guid.Empty) return NotFound();
 
             var todo = await _todoItemService.GetItemAsync(id);
+
+            if (todo == null) return NotFound();
+
             var deleteViewModel = new DeleteViewModel()
             {
                 Id = todo.Id,


### PR DESCRIPTION
Hi! 👋

This PR adds test coverage as discussed in https://github.com/amoraitis/TodoList/issues/1

Right now I'm only adding coverage for controllers, the idea is to add test coverage incrementally for old features, and always add tests when a new feature is going to be implemented.

The controllers covered are the following ones:

- AccountController
- HomeController
- ManageController
- ManageUsersController
- TodosController

A new line was added to the `.travis.yml` file:

` - dotnet test Amoraitis.Todo.UnitTests/`

This way we avoid breaking the application with a new non-well tested feature.

___

**Note**: because of the static nature of some extension methods I couldn't test all methods in the controllers, so we didn't achieve 100% coverage in controllers, nevertheless we went from 0% coverage in the whole project to _something%_, I think we are achieving great things.

The untested methods are the followings:

`ManageController`
- SendVerificationEmail
- LinkLogin

`AccountController`
- Register [HttpPost]
- ExternalLogin
- PostForgotPassword

`TodosController`
- UploadFile

Anyway, I was reading about isolation test frameworks which can change the behavior of static methods, using one of them we could i.e mock the `UrlHelper.EmailConfirmationLink` static method to test `ManageController.SendVerificationEmail` method.

___

**Note**: like we're adding tests to the application after and not before, I tried to not change the current implementations, anyway I made some minor changes.

___

I worked really hard to accomplish this, I hope I did a good job. If there is anything I can do to improve it just tell me and I'll do it.

Greetings 😄