### PR TITLE
Fixed: Migrations where not applied

### DIFF
--- a/TodoList.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/TodoList.Web/Extensions/ServiceCollectionExtensions.cs
@@ -66,7 +66,7 @@ namespace TodoList.Web.Extensions
         {
             services.AddEntityFrameworkSqlServer().AddDbContext<ApplicationDbContext>(options =>
             {
-                options.UseSqlServer(configuration["ConnectionStrings:Connection"]);
+                options.UseSqlServer(configuration["ConnectionStrings:Connection"], x => x.MigrationsAssembly("TodoList.Data"));
             });
         }
 


### PR DESCRIPTION
Without this the created Database was empty.

And it is suggested by Microsoft to add this setting if the migrations are in a different project:
[Microsoft: Using a Separate Migrations Project](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/projects)